### PR TITLE
feat: add GET /users/{id}/tweets with cursor-based pagination

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -203,6 +203,56 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 
+  /users/{id}/tweets:
+    get:
+      summary: Get user's tweets
+      description: Retrieve a paginated list of tweets posted by the specified user (cursor-based pagination using UUID v7)
+      operationId: getUserTweets
+      tags:
+        - tweets
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: cursor
+          in: query
+          description: Cursor (tweet ID) to fetch tweets older than. Omit to start from the newest.
+          required: false
+          schema:
+            type: string
+            format: uuid
+        - name: limit
+          in: query
+          description: Number of tweets to return (default 20, max 100)
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 20
+      responses:
+        '200':
+          description: List of user's tweets
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserTweetsResponse'
+        '400':
+          description: Invalid request parameters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: User not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
   /users/{id}/follow:
     put:
       summary: Follow user
@@ -597,6 +647,43 @@ components:
             $ref: '#/components/schemas/User'
       required:
         - users
+
+    CursorPagination:
+      type: object
+      properties:
+        cursor:
+          type: string
+          format: uuid
+          nullable: true
+          description: Cursor value used in the current request. Null if not specified.
+          example: "0190a5e4-b890-7000-8000-000000000010"
+        limit:
+          type: integer
+          description: Maximum number of items to return per page
+          example: 20
+        next_cursor:
+          type: string
+          format: uuid
+          nullable: true
+          description: Cursor to use for the next page. Null if this is the last page.
+          example: "0190a5e4-b890-7000-8000-000000000005"
+      required:
+        - cursor
+        - limit
+        - next_cursor
+
+    UserTweetsResponse:
+      type: object
+      properties:
+        tweets:
+          type: array
+          items:
+            $ref: '#/components/schemas/Tweet'
+        pagination:
+          $ref: '#/components/schemas/CursorPagination'
+      required:
+        - tweets
+        - pagination
 
     Error:
       type: object

--- a/internal/domain/models.go
+++ b/internal/domain/models.go
@@ -106,3 +106,14 @@ type GetFeedResponse struct {
 	Tweets     []TweetWithUser `json:"tweets"`
 	Pagination Pagination      `json:"pagination"`
 }
+
+type CursorPagination struct {
+	Cursor     *string `json:"cursor"`
+	Limit      int64   `json:"limit"`
+	NextCursor *string `json:"next_cursor"`
+}
+
+type GetUserTweetsResponse struct {
+	Tweets     []Tweet          `json:"tweets"`
+	Pagination CursorPagination `json:"pagination"`
+}


### PR DESCRIPTION
## Summary

- Closes #5
- `GET /users/{id}/tweets` エンドポイントを追加（認証不要・公開）
- UUID v7のソート可能な特性を活用し、cursor-based ページネーションを実装（OFFSETに比べ件数増加時にパフォーマンス劣化しない）

## 変更内容

| ファイル | 変更 |
|---|---|
| `internal/domain/models.go` | `CursorPagination`・`GetUserTweetsResponse` 型を追加 |
| `internal/repository/tweet_repository.go` | `GetTweetsByUserID` メソッドを追加（cursor 有無で SQL を切り替え） |
| `main.go` | `getUserTweetsHandler` を実装し公開ルートに登録 |
| `docs/openapi.yaml` | エンドポイント・レスポンススキーマの仕様を追加 |

## ページネーション設計

- `cursor` 未指定 → 最新ツイートから取得
- `cursor` 指定 → そのIDより古いツイートから取得 (`id < cursor`)
- `limit+1` 件 SELECT して次ページ判定（既存パターンと同様）
- `next_cursor` は返したツイートの末尾のID（次ページ無ければ `null`）

## Test plan

- [ ] `GET /users/{valid-id}/tweets` で最新ツイートが降順に返されることを確認
- [ ] `cursor` パラメータで次ページが正しく取得されることを確認
- [ ] `limit` のバリデーション（1〜100の範囲外）で400が返されることを確認
- [ ] 存在しないユーザーIDで404が返されることを確認
- [ ] 無効なcursor（UUID以外）で400が返されることを確認
- [ ] ツイートが0件のユーザーで空配列が返されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)